### PR TITLE
added deps.edn, support for 'false' to denote wildcard key for maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
-
+.cpcache
 supdate.iml
 .idea

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,2 @@
+{:deps {criterium {:mvn/version "0.4.5"}
+        midje     {:mvn/version "1.9.8"}}}

--- a/src/vvvvalvalval/supdate/impl.cljc
+++ b/src/vvvvalvalval/supdate/impl.cljc
@@ -7,10 +7,15 @@
   (let [not-found #?(:clj (Object.) :cljs (js-obj))]
     (fn upd*
       [m k f]
-      (let [v (get m k not-found)]
-        (if (identical? v not-found)
-          m
-          (assoc m k (f v))))
+      (if (false? k)
+        (reduce-kv (fn [acc k v]
+                     (assoc acc k (f v)))
+                   {}
+                   m)
+        (let [v (get m k not-found)]
+          (if (identical? v not-found)
+            m
+            (assoc m k (f v)))))
       )))
 
 (def upd-dynamic*
@@ -20,12 +25,19 @@
   (let [not-found #?(:clj (Object.) :cljs (js-obj))]
     (fn upd-dynamic*
       [m k f]
-      (let [v (get m k not-found)]
-        (if (identical? v not-found)
-          m
-          (if (false? f)
-            (dissoc m k)
-            (assoc m k (f v)))))
+      (if (false? k)
+        (reduce-kv (fn [acc k v]
+                     (if (false? f)
+                       acc
+                       (assoc acc k (f v))))
+                   {}
+                   m)
+        (let [v (get m k not-found)]
+          (if (identical? v not-found)
+            m
+            (if (false? f)
+              (dissoc m k)
+              (assoc m k (f v))))))
       )))
 
 (defn supd-map*

--- a/test/vvvvalvalval/supdate/test/api.clj
+++ b/test/vvvvalvalval/supdate/test/api.clj
@@ -107,3 +107,7 @@
     :c {"d" [{:e 2, :f 1} {:e 3, :f 2}]}
     :g 3,
     :h 0}
+
+(fact
+ "a map with a false key will be applied as a wildcard against all keys"
+ (supdate {:a 5 :b 10} {false inc}))


### PR DESCRIPTION
Since 'supdate' has already established the idea of "false" as a magical value (for key dissoc) it seem like an obvious extension to accept "false" as a magic value for map keys as well- In that case, the obvious operation is to treat it as a wildcard key value, mapping updates against all vals in the map, which is a frequently needed ability:

(supdate {:a 5 :b 10} {false inc}) => {:a 6 :b 11}

Also:
1. This is a matter of "taste" so I won't be offended if you don't like this idea.
2. There may be ways to better optimize the compile-time handling for this, I couldn't figure out an obvious way to do it that made sense to me.